### PR TITLE
Support masking multi-line values

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -27,6 +27,7 @@ jobs:
         uses: ./
         with:
           yaml-file: test-values.yaml
+          mask-vars: true
 
       - name: Test env
         run: |

--- a/scripts/yaml-to-env.sh
+++ b/scripts/yaml-to-env.sh
@@ -59,7 +59,7 @@ for _line in "${_lines[@]}"; do
 
   if [[ "${YAMLTOENV_MASK_VARS}" == 'true' ]]; then
     # sourced https://dev.to/yuyatakeyama/mask-multiple-lines-text-in-github-actions-workflow-1a0
-    echo "::add-mask::$(echo "$_clean_value" | sed ':a;N;$!ba;s/%/%25/g' | sed ':a;N;$!ba;s/\r/%0D/g' | sed ':a;N;$!ba;s/\n/%0A/g')"
+    echo "::add-mask::$(echo "$_clean_value" | sed -e 's/\\n/\n/g' | sed ':a;N;$!ba;s/%/%25/g' | sed ':a;N;$!ba;s/\r/%0D/g' | sed ':a;N;$!ba;s/\n/%0A/g')"
   fi
 
   _yaml_keys+=("${_key}")

--- a/scripts/yaml-to-env.sh
+++ b/scripts/yaml-to-env.sh
@@ -8,8 +8,8 @@ function _upper() { printf '%s' "${1}" | tr '[:lower:]' '[:upper:]'; }
 function _env_name() {  _upper "${1}" | sed -E 's/[^a-zA-Z0-9_]/_/g'; }
 
 _write_env_file_line() {
-  printf '%s' "${1}" | sed -e 's/\\n/\n/g' >> $GITHUB_ENV
-  printf '\n' >> $GITHUB_ENV
+  printf '%s' "${1}" | sed -e 's/\\n/\n/g' >> "$GITHUB_ENV"
+  printf '\n' >> "$GITHUB_ENV"
 }
 
 _write_kv_to_env_file() {
@@ -58,7 +58,7 @@ for _line in "${_lines[@]}"; do
   _clean_value="$(_ltrim_one "${_value}")"
 
   if [[ "${YAMLTOENV_MASK_VARS}" == 'true' ]]; then
-    echo "::add-mask::${_clean_value}"
+    echo "::add-mask::$_clean_value"
   fi
 
   _yaml_keys+=("${_key}")
@@ -68,6 +68,6 @@ for _line in "${_lines[@]}"; do
 
 done
 
-echo "var-count=${#_env_names[@]}" >> $GITHUB_OUTPUT
-echo "yaml-keys=$(_join_by "," "${_yaml_keys[@]}")" >> $GITHUB_OUTPUT
-echo "env-names=$(_join_by "," "${_env_names[@]}")" >> $GITHUB_OUTPUT
+echo "var-count=${#_env_names[@]}" >> "$GITHUB_OUTPUT"
+echo "yaml-keys=$(_join_by "," "${_yaml_keys[@]}")" >> "$GITHUB_OUTPUT"
+echo "env-names=$(_join_by "," "${_env_names[@]}")" >> "$GITHUB_OUTPUT"

--- a/scripts/yaml-to-env.sh
+++ b/scripts/yaml-to-env.sh
@@ -59,7 +59,7 @@ for _line in "${_lines[@]}"; do
 
   if [[ "${YAMLTOENV_MASK_VARS}" == 'true' ]]; then
     # sourced https://dev.to/yuyatakeyama/mask-multiple-lines-text-in-github-actions-workflow-1a0
-    echo "::add-mask::$(echo "$_clean_value" | sed ':a;N;$!ba;s/%/%25/g' | sed ':a;N;$!ba;s/\r/%0D/g' | sed ':a;N;$!ba;s/\n/%0A/g')
+    echo "::add-mask::$(echo "$_clean_value" | sed ':a;N;$!ba;s/%/%25/g' | sed ':a;N;$!ba;s/\r/%0D/g' | sed ':a;N;$!ba;s/\n/%0A/g')"
   fi
 
   _yaml_keys+=("${_key}")

--- a/scripts/yaml-to-env.sh
+++ b/scripts/yaml-to-env.sh
@@ -58,7 +58,8 @@ for _line in "${_lines[@]}"; do
   _clean_value="$(_ltrim_one "${_value}")"
 
   if [[ "${YAMLTOENV_MASK_VARS}" == 'true' ]]; then
-    echo "::add-mask::$_clean_value"
+    # sourced https://dev.to/yuyatakeyama/mask-multiple-lines-text-in-github-actions-workflow-1a0
+    echo "::add-mask::$(echo "$_clean_value" | sed ':a;N;$!ba;s/%/%25/g' | sed ':a;N;$!ba;s/\r/%0D/g' | sed ':a;N;$!ba;s/\n/%0A/g')
   fi
 
   _yaml_keys+=("${_key}")


### PR DESCRIPTION
Hello!

My use case for wanting to mask the env variable values #2 involves multi-line values. I came across this [article](https://dev.to/yuyatakeyama/mask-multiple-lines-text-in-github-actions-workflow-1a0) on masking multi-line text, and incorporated it into the yaml-to-env.sh script. Testing with my fork it is working for me and the multi-line values are all correctly masked.

I updated the Test Action workflow which should show it is working correctly as well. An example of the workflow running and variables being masked can be found [here](https://github.com/channingko-madden/yaml-to-env-action/actions/runs/11688922050/job/32550491509), under the `Test env` step.